### PR TITLE
Adicionar middleware CorrelationId para rastreamento de requests

### DIFF
--- a/src/FiapCloudGames.API/Middlewares/CorrelationIdMiddleware.cs
+++ b/src/FiapCloudGames.API/Middlewares/CorrelationIdMiddleware.cs
@@ -1,0 +1,17 @@
+namespace FiapCloudGames.API.Middlewares;
+
+public sealed class CorrelationIdMiddleware(RequestDelegate next)
+{
+    private const string HeaderName = "X-Correlation-Id";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var correlationId = context.Request.Headers[HeaderName].FirstOrDefault()
+            ?? Guid.NewGuid().ToString();
+
+        context.TraceIdentifier = correlationId;
+        context.Response.Headers[HeaderName] = correlationId;
+
+        await next(context);
+    }
+}

--- a/src/FiapCloudGames.API/Program.cs
+++ b/src/FiapCloudGames.API/Program.cs
@@ -64,6 +64,7 @@ try
 
     var app = builder.Build();
 
+    app.UseMiddleware<CorrelationIdMiddleware>();
     app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
     app.UseSerilogRequestLogging();
 


### PR DESCRIPTION
## Summary
- Criar `CorrelationIdMiddleware` que propaga `X-Correlation-Id` entre request/response
- Se o header nao vier no request, gera um GUID automaticamente
- Define `HttpContext.TraceIdentifier` para integracao com Serilog enricher
- Posicionado antes do GlobalExceptionHandler no pipeline

## Test plan
- [x] `dotnet build` — 0 erros, 0 warnings
- [x] 151 testes unitarios passando
- [x] Header `X-Correlation-Id` retornado com GUID gerado automaticamente
- [x] Header `X-Correlation-Id` propagado quando enviado no request

Closes #46