### PR TITLE
Corrigir autenticação do Swagger UI

### DIFF
--- a/src/FiapCloudGames.API/Program.cs
+++ b/src/FiapCloudGames.API/Program.cs
@@ -32,11 +32,9 @@ try
 
         options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
         {
-            Name = "Authorization",
-            Description = "Informe o token JWT no formato: Bearer {seu_token}",
-            In = ParameterLocation.Header,
-            Type = SecuritySchemeType.ApiKey,
-            Scheme = "Bearer",
+            Description = "Informe apenas o token JWT (sem o prefixo 'Bearer').",
+            Type = SecuritySchemeType.Http,
+            Scheme = "bearer",
             BearerFormat = "JWT"
         });
 


### PR DESCRIPTION
## Resumo
- Corrigir configuração do SecurityScheme no Swagger de `ApiKey` para `Http` com scheme `bearer`
- O Swagger UI não enviava o header `Authorization` nas requisições, causando 401 em todos os endpoints autenticados
- Atualizar descrição para orientar o usuário a informar apenas o token (sem prefixo "Bearer")

## Plano de teste
- [x] `dotnet test` — 177 testes passando (151 unitários + 26 integração)
- [x] Swagger JSON retorna `type: http` e `scheme: bearer`
- [x] Login → token → requisição autenticada retorna 200
- [x] Requisição sem token retorna 401