### PR TITLE
Corrigir SecurityRequirement do Swagger para enviar token JWT

### DIFF
--- a/src/FiapCloudGames.API/Program.cs
+++ b/src/FiapCloudGames.API/Program.cs
@@ -38,12 +38,9 @@ try
             BearerFormat = "JWT"
         });
 
-        options.AddSecurityRequirement(_ => new OpenApiSecurityRequirement
+        options.AddSecurityRequirement(document => new OpenApiSecurityRequirement
         {
-            {
-                new OpenApiSecuritySchemeReference("Bearer"),
-                new List<string>()
-            }
+            [new OpenApiSecuritySchemeReference("Bearer", document)] = []
         });
 
         var xmlFiles = Directory.GetFiles(AppContext.BaseDirectory, "*.xml", SearchOption.TopDirectoryOnly);


### PR DESCRIPTION
## Resumo
- Passar `document` como segundo argumento do `OpenApiSecuritySchemeReference` para que a referência seja resolvida corretamente durante a serialização
- Sem o `document`, o swagger.json produzia `security: [{}]` ao invés de `security: [{"Bearer": []}]`, impedindo o Swagger UI de enviar o header Authorization
- Complemento da PR #65 — a correção do `SecuritySchemeType` entrou mas esta parte ficou de fora

## Plano de teste
- [x] `dotnet test` — 177 testes passando
- [x] swagger.json gera `security: [{"Bearer": []}]`
- [x] Login → token → requisição autenticada retorna 200